### PR TITLE
PowerShell 5.1 does not support -UtcNow parameter for Get-Date

### DIFF
--- a/PureStorage.FlashArray.Reporting/Public/Invoke-PfaApiRequest.ps1
+++ b/PureStorage.FlashArray.Reporting/Public/Invoke-PfaApiRequest.ps1
@@ -86,7 +86,7 @@ function Invoke-PfaApiRequest {
         } else {
             $ApiUri = $ApiVersion
         }
-        if ($Array.Expires -le (Get-Date -AsUTC)) {
+        if ($Array.Expires -le [DateTime]::UtcNow) {
             Connect-PfaApi -Array $Array -SkipCertificateCheck:$SkipCertificateCheck
         }
 


### PR DESCRIPTION
Fixes #1